### PR TITLE
Fix for Coq PR 13986

### DIFF
--- a/ordinal.v
+++ b/ordinal.v
@@ -9,6 +9,7 @@
 (** * ordinal: finite ordinals, sets of finite ordinals *)
 
 Require Import List.
+Require Plus.
 Require Import common comparisons.
 
 


### PR DESCRIPTION
In an effort https://github.com/coq/coq/pull/13986 to streamline Coq's `List.v`, dependencies on `Arith` modules are removed.
Therefore, importing `List` will not provide `Arith` functionality. Resulting issues are fixed by this PR.