### PR TITLE
Adapt to coq/coq#14773 (convert_concl has a ~cast argument)

### DIFF
--- a/kat_reification.mlg
+++ b/kat_reification.mlg
@@ -387,7 +387,7 @@ let reify_kat_goal ?kat check =
     mkNamedLetIn rhs_n rhs_v x (
       (mkApp (rel, [|lhs;rhs|])))))))))
   in	  
-  (try Proofview.V82.of_tactic (Tactics.convert_concl ~check:true reified DEFAULTcast) goal
+  (try Proofview.V82.of_tactic (Tactics.convert_concl ~cast:false ~check:true reified DEFAULTcast) goal
    with e -> Feedback.msg_warning (Printer.pr_leconstr_env (fst es) (snd es) reified); raise e))
   end
 
@@ -468,7 +468,7 @@ let get_kat_alphabet =
     mkNamedLetIn alph_n alph_v (Lattice.car (Monoid.mor mops src' tgt'))
       (Tacmach.pf_concl goal)
   in	  
-    (try Proofview.V82.of_tactic (Tactics.convert_concl ~check:true reified DEFAULTcast) goal
+    (try Proofview.V82.of_tactic (Tactics.convert_concl ~cast:false ~check:true reified DEFAULTcast) goal
      with e -> (* Feedback.msg_warning (Printer.pr_lconstr reified); *) raise e)
   end
 }

--- a/ra_fold.mlg
+++ b/ra_fold.mlg
@@ -143,7 +143,7 @@ let ra_fold_concl ops ob = Goal.enter (fun goal ->
   let goal = Goal.print goal in
   let env = Tacmach.pf_env goal in
   let f,sigma = ra_fold_term ops ob (Tacmach.pf_concl goal) goal in
-  (try tclTHEN (Unsafe.tclEVARS sigma) (Tactics.convert_concl ~check:true f DEFAULTcast)
+  (try tclTHEN (Unsafe.tclEVARS sigma) (Tactics.convert_concl ~cast:false ~check:true f DEFAULTcast)
    with e -> Feedback.msg_warning (Printer.pr_leconstr_env env sigma f); raise e))
 
 let ra_fold_hyp' ops ob decl goal =

--- a/ra_reification.mlg
+++ b/ra_reification.mlg
@@ -206,7 +206,7 @@ let reify_goal l goal =
     mkNamedLetIn rhs_n rhs_v x (
     (mkApp (rel, [|lhs;rhs|]))))))))
   in
-    (try Tacticals.tclTHEN (retype reified) (Proofview.V82.of_tactic (Tactics.convert_concl ~check:true reified DEFAULTcast)) goal
+    (try Tacticals.tclTHEN (retype reified) (Proofview.V82.of_tactic (Tactics.convert_concl ~cast:false ~check:true reified DEFAULTcast)) goal
      with e -> Feedback.msg_warning (Printer.pr_leconstr_env (fst es) (snd es) reified); raise e)
 
 }	


### PR DESCRIPTION
With DEFAULTcast cast:false is the previous behaviour, otherwise cast:true.