### PR TITLE
Fix for coq PR #13969

### DIFF
--- a/lattice.v
+++ b/lattice.v
@@ -140,6 +140,8 @@ Proof.
    intros x y z. rewrite 3weq_spec. intuition; etransitivity; eassumption.
 Qed.
 
+#[export] Instance weq_rel {ops} : RewriteRelation (@weq ops) := {}.
+
 #[export] Instance weq_leq `{laws}: subrelation weq leq.
 Proof. intros x y E. apply weq_spec in E as [? ?]. assumption. Qed.
 

--- a/matrix.v
+++ b/matrix.v
@@ -352,7 +352,7 @@ Lemma mx_dot_rowcol n m1 m2 p (M1: mx n m1) (M2: mx n m2) (N1: mx m1 p) (N2: mx 
   row_mx M1 M2 ⋅ col_mx N1 N2 ≡ M1⋅N1 + M2⋅N2.
 Proof.
   intros i j. setoid_rewrite sup_cut. unfold row_mx, col_mx. 
-  setoid_rewrite split_lshift. setoid_rewrite split_rshift. reflexivity. (* LONG *)
+  setoid_rewrite split_lshift. setoid_rewrite split_rshift. reflexivity.
 Qed.
 
 Lemma mx_dot_blk n1 n2 m1 m2 p1 p2 


### PR DESCRIPTION
This allows coq/coq#13969 to go through, by declaring `weq` as a rewrite relation, that might be inferred by setoid rewrite when it must guess a relation on a type.
Typically happens when one rewrites with eq in a context that only has `weq` morphisms for the surrounding context. 
This should be backwards-compatible.