### PR TITLE
Adapt to rocq-prover/rocq#21630 (interp_sign moved to tacinterp)

### DIFF
--- a/src/common.ml
+++ b/src/common.ml
@@ -81,7 +81,7 @@ let get_fun_13 d s = let v = get_const d s in fun x y z t u r w p q q1 q2 q3 q4 
 let get_fun_14 d s = let v = get_const d s in fun x y z t u r w p q q1 q2 q3 q4 q5 -> force_app v [|x;y;z;t;u;r;w;p;q;q1;q2;q3;q4;q5|]
 
 let ltac_apply ist (f: Tacinterp.value) (arg : constr) =
-  let open Geninterp in
+  let open Ltac_plugin.Tacinterp in
   let f_ = Id.of_string "f" in
   let x_ = Id.of_string "x" in
   let arg = Tacinterp.Value.of_constr arg in

--- a/src/common.mli
+++ b/src/common.mli
@@ -109,7 +109,7 @@ val get_fun_14 :
   EConstr.t ->
   EConstr.t -> EConstr.t -> EConstr.t -> EConstr.t -> EConstr.t -> EConstr.t
 val ltac_apply :
-  Geninterp.interp_sign ->
+  Ltac_plugin.Tacinterp.interp_sign ->
   Ltac_plugin.Tacinterp.value -> EConstr.constr -> unit Proofview.tactic
 module Rocq : sig val path : string list val true_ : EConstr.t lazy_t end
 module Pos :

--- a/src/mrewrite.mli
+++ b/src/mrewrite.mli
@@ -1,4 +1,4 @@
 val extend :
-  Geninterp.interp_sign ->
+  Ltac_plugin.Tacinterp.interp_sign ->
   Ltac_plugin.Tacinterp.value ->
   [< `LR | `RL ] -> EConstr.constr -> unit Proofview.tactic


### PR DESCRIPTION
It was already reexported in tacinterp so this should be backwards compatible